### PR TITLE
Likely 'angular' confusion with 'linear'

### DIFF
--- a/Proyecto2/src/ekbot_ctrl/robot_velocity_node.cpp
+++ b/Proyecto2/src/ekbot_ctrl/robot_velocity_node.cpp
@@ -56,7 +56,7 @@ double* getMotorValue(int x_velocity, int y_velocity, int w_velocity){
 void get_vel_vec(const geometry_msgs::Twist& msg) {
 	velocity_msg.linear.x = msg.linear.x;
 	velocity_msg.linear.y = msg.linear.y;
-    velocity_msg.angular.z = msg.linear.z; 
+    velocity_msg.angular.z = msg.angular.z; 
 }
 
 


### PR DESCRIPTION
Hello EagleKnights,

My name is John-Paul Ore and I'm a software researcher at the University of Nebraska-Lincoln.

This appears to an accidental usage of 'linear.z' in place of 'angular.z', detected using my tool 'Phriky Units'.

https://github.com/unl-nimbus-lab/phriky-units

Cheers - JP